### PR TITLE
Changed apertype files to octagons

### DIFF
--- a/aperture/aperture_upgrade_IT.madx
+++ b/aperture/aperture_upgrade_IT.madx
@@ -1,15 +1,3 @@
-write_OCTAGON(xx1,yy1,xx2,yy2): macro = {
- printf,text=" %g  %g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx1,yy1;
-};
-
 aperture_def(eee,ttt,ap1,ap2,ap3,ap4,rtol,htol,vtol): macro={
 eeeL1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
 eeeR1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
@@ -41,18 +29,9 @@ if (bs_type == OCTA2015) {
   r_Q1=sqrt((sqrt(2)*r1_Q1-r2_Q1)^2+r2_Q1^2)/1e3;
   g_Q1=r1_Q1/1e3;
   hv_Q1=r1_Q1/1e3;
-  angle1_Q1=45-acos(g_Q1/r_Q1)/pi*180; !22.5 regular octagon
-  angle2_Q1=90-angle1_Q1;
+  angle1_Q1=pi/4-acos(g_Q1/r_Q1); !22.5 regular octagon
+  angle2_Q1=pi/2-angle1_Q1;
   value,r_Q1,g_Q1,angle1_Q1,angle2_Q1;
-  xx1=r_Q1*cos(angle1_Q1/180*pi);!conversion to m
-  yy1=r_Q1*sin(angle1_Q1/180*pi);
-  xx2=r_Q1*cos(angle2_Q1/180*pi);
-  yy2=r_Q1*sin(angle2_Q1/180*pi);
-  value,xx1,yy1,xx2,yy2;
-  system, "rm  -f q1_aperture";
-  assign, echo="q1_aperture";
-  exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-  assign, echo=terminal;
 
   !r1_Q23=114/2-1.5*(1-no_bs_tol); !C. Garion 9/5/2015 1.5 mech tol
   !r2_Q23=122/2-1.5*(1-no_bs_tol); !C. Garion 9/5/2015 1.5 mech tol
@@ -61,20 +40,9 @@ if (bs_type == OCTA2015) {
   r_Q23=sqrt((sqrt(2)*r1_Q23-r2_Q23)^2+r2_Q23^2)/1e3;
   g_Q23=r1_Q23/1e3;
   hv_Q23=r2_Q23/1e3;
-  angle1_Q23=45-acos(g_Q23/r_Q23)/pi*180; !22.5 regular octagon
-  angle2_Q23=90-angle1_Q23;
+  angle1_Q23=pi/4-acos(g_Q23/r_Q23); !22.5 regular octagon
+  angle2_Q23=pi/2-angle1_Q23;
   value,r_Q23,g_Q23,angle1_Q23,angle2_Q23;
-  xx1=r_Q23*cos(angle1_Q23/180*pi);!conversion to m
-  yy1=r_Q23*sin(angle1_Q23/180*pi);
-  xx2=r_Q23*cos(angle2_Q23/180*pi);
-  yy2=r_Q23*sin(angle2_Q23/180*pi);
-  value,xx1,yy1,xx2,yy2;
-
-  system, "rm  -f q23_aperture";
-  assign, echo="q23_aperture";
-  exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-  assign, echo=terminal;
-
 };
 
 !r_TAS   := 0.0270;     ! was 24 mm in slhcv1 and 25 mm in slhcv2 and 30 mm in slhc3, hllhc1.1
@@ -103,33 +71,33 @@ r_tol_DFXJ:=0.0020+r_tol_TAS_mod; h_tol_DFXJ:=0.0005+h_tol_TAS_mod; v_tol_DFXJ:=
 
 exec, aperture_def(TAXS.1  , rectellipse , r_TAS, r_TAS, r_TAS     , r_TAS     , r_tol_TAS, h_tol_TAS, v_tol_TAS);
 
-exec, aperture_def(MQXFA.A1, q1_aperture , hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
-exec, aperture_def(MQXFA.B1, q1_aperture , hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
+exec, aperture_def(MQXFA.A1,   OCTAGON, hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1, h_tol_Q1, v_tol_Q1);
+exec, aperture_def(MQXFA.B1,   OCTAGON, hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1, h_tol_Q1, v_tol_Q1);
 
-exec, aperture_def(MQXFB.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
-exec, aperture_def(MQXFB.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2 , h_tol_Q2 , v_tol_Q2);
+exec, aperture_def(MQXFB.A2,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MQXFB.B2,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
 
-exec, aperture_def(MQXFA.A3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
-exec, aperture_def(MQXFA.B3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3 , h_tol_Q3 , v_tol_Q3);
+exec, aperture_def(MQXFA.A3,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MQXFA.B3,   OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
 
-exec, aperture_def(MCBXFBH.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBV.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBH.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
-exec, aperture_def(MCBXFBV.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBH.A2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBV.A2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBH.B2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
+exec, aperture_def(MCBXFBV.B2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q2, h_tol_Q2, v_tol_Q2);
 
-exec, aperture_def(MCBXFAV.3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCBXFAH.3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MQSXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCSXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCTXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCTSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCSSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCOSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCOXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCDSXF.3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_def(MCDXF.3  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCBXFAV.3,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCBXFAH.3,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MQSXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCSXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCTXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCTSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCSSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCOSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCOXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCDSXF.3 ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_def(MCDXF.3  ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
 
-exec, aperture_def(MBXF.4   , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_D1, h_tol_D1, v_tol_D1);
+exec, aperture_def(MBXF.4   ,  OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_D1, h_tol_D1, v_tol_D1);
 
 exec, aperture_def(DFXJ.4   , rectellipse, r_DFXJ, r_DFXJ, r_DFXJ, r_DFXJ, r_tol_DFXJ, h_tol_DFXJ, v_tol_DFXJ);
 
@@ -142,11 +110,11 @@ exec, aperture_def(DFXJ.4   , rectellipse, r_DFXJ, r_DFXJ, r_DFXJ, r_DFXJ, r_tol
 !exec, aperture_2in1_def(BPMSQ.4  , rectellipse, r_BPMSQ , r_BPMSQ , r_BPMSQ , r_BPMSQ , r_tol_BPM, h_tol_BPM, v_tol_BPM);
 !exec, aperture_2in1_def(BPMSQW.4  , rectellipse, r_BPMSQ4 , r_BPMSQ4 , r_BPMSQ4 , r_BPMSQ4 , r_tol_BPM, h_tol_BPM, v_tol_BPM);
 
-exec, aperture_2in1_def(BPMSQW.1 , q1_aperture, hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1 , h_tol_Q1 , v_tol_Q1);
-exec, aperture_2in1_def(BPMSQ.1  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_2in1_def(BPMSQ.A2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_2in1_def(BPMSQT.B2, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_2in1_def(BPMSQ.A3, q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_2in1_def(BPMSQ.B3 , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
-exec, aperture_2in1_def(BPMSQ.4  , q23_aperture, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQW.1 , OCTAGON, hv_q1 , hv_q1 , angle1_q1 , angle2_q1 , r_tol_Q1, h_tol_Q1, v_tol_Q1);
+exec, aperture_2in1_def(BPMSQ.1  , OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQ.A2 , OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQT.B2, OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQ.A3 , OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQ.B3 , OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
+exec, aperture_2in1_def(BPMSQ.4  , OCTAGON, hv_q23, hv_q23, angle1_q23, angle2_q23, r_tol_Q3, h_tol_Q3, v_tol_Q3);
 exec, aperture_2in1_def(BPMSQW.4 , rectellipse, r_BPMSQ4W , r_BPMSQ4W , r_BPMSQ4W , r_BPMSQ4W , r_tol_BPM, h_tol_BPM, v_tol_BPM);

--- a/aperture/aperture_upgrade_MS.madx
+++ b/aperture/aperture_upgrade_MS.madx
@@ -20,18 +20,6 @@
 
 ! Macros
 
-write_OCTAGON(xx1,yy1,xx2,yy2): macro = {
- printf,text=" %g  %g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx1,yy1;
-};
-
 aperture_2in1_def(eee,ttt,ap1,ap2,ap3,ap4,rtol,htol,vtol): macro={
 eeeL1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
 eeeR1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
@@ -78,25 +66,13 @@ r_D2=sqrt((sqrt(2)*r1_D2-r2_D2)^2+r2_D2^2)/1e3;
 g_D2=r1_D2/1e3;
 hv_D2=r2_D2/1e3;
 
-angle1_D2=45-acos(g_d2/r_d2)/pi*180; !22.5 regular octagon
+angle1_D2=pi/4-acos(g_d2/r_d2); !22.5 regular octagon
 angle2_D2=90-angle1_D2;
 
 value,r_D2,g_D2,angle1_D2,angle2_D2;
 
-xx1=r_D2*cos(angle1_D2/180*pi);!conversion to m
-yy1=r_D2*sin(angle1_D2/180*pi);
-xx2=r_D2*cos(angle2_D2/180*pi);
-yy2=r_D2*sin(angle2_D2/180*pi);
-
-value,xx1,yy1,xx2,yy2;
-
-system,"rm d2_aperture";assign, echo="d2_aperture";
-exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-assign, echo=terminal;
-
-exec,aperture_2in1_def(MBRD.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
-!exec,aperture_2in1_def(TCLMA.4,d2_aperture,
+exec,aperture_2in1_def(MBRD.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
+!exec,aperture_2in1_def(TCLMA.4,OCTAGON,
 !          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
 
 ! big corrector for crabs
@@ -105,10 +81,8 @@ exec,aperture_2in1_def(MBRD.4,d2_aperture,
 !g_MC2=g_D2;r_MC2=r_D2; !equal to D2 for the time being
 !r_tol_MC2 =r_tol_D2; h_tol_MC2 :=h_tol_D2+h_tol_MC2_mod; v_tol_MC2 :=v_tol_D2+v_tol_MC2_mod;
 
-exec,aperture_2in1_def(MCBRDH.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2 , h_tol_C2 , v_tol_C2);
-exec,aperture_2in1_def(MCBRDV.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2 , h_tol_C2 , v_tol_C2);
+exec,aperture_2in1_def(MCBRDH.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2,h_tol_C2,v_tol_C2);
+exec,aperture_2in1_def(MCBRDV.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2,h_tol_C2,v_tol_C2);
 
 
 

--- a/aperture/aperture_upgrade_MS_2.madx
+++ b/aperture/aperture_upgrade_MS_2.madx
@@ -20,18 +20,6 @@
 
 ! Macros
 
-write_OCTAGON(xx1,yy1,xx2,yy2): macro = {
- printf,text=" %g  %g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx2,yy2;
- printf,text="-%g  %g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx1,yy1;
- printf,text="-%g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx2,yy2;
- printf,text=" %g -%g",value=xx1,yy1;
- printf,text=" %g  %g",value=xx1,yy1;
-};
-
 aperture_2in1_def(eee,ttt,ap1,ap2,ap3,ap4,rtol,htol,vtol): macro={
 eeeL1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
 eeeR1.B1,APERTYPE=ttt,APERTURE:={ap1,ap2,ap3,ap4},APER_TOL:={rtol,htol,vtol};
@@ -78,26 +66,13 @@ r_D2=sqrt((sqrt(2)*r1_D2-r2_D2)^2+r2_D2^2)/1e3;
 g_D2=r1_D2/1e3;
 hv_D2=r2_D2/1e3;
 
-angle1_D2=45-acos(g_d2/r_d2)/pi*180; !22.5 regular octagon
-angle2_D2=90-angle1_D2;
+angle1_D2=pi/4-acos(g_d2/r_d2); !22.5 regular octagon
+angle2_D2=pi/2-angle1_D2;
 
 value,r_D2,g_D2,angle1_D2,angle2_D2;
 
-xx1=r_D2*cos(angle1_D2/180*pi);!conversion to m
-yy1=r_D2*sin(angle1_D2/180*pi);
-xx2=r_D2*cos(angle2_D2/180*pi);
-yy2=r_D2*sin(angle2_D2/180*pi);
-
-value,xx1,yy1,xx2,yy2;
-
-system,"rm d2_aperture";assign, echo="d2_aperture";
-exec,write_OCTAGON(xx1,yy1,xx2,yy2);
-assign, echo=terminal;
-
-exec,aperture_2in1_def(MBRD.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
-!exec,aperture_2in1_def(TCLMA.4,d2_aperture,
-!          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
+exec,aperture_2in1_def(MBRD.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2,h_tol_D2,v_tol_D2);
+!exec,aperture_2in1_def(TCLMA.4,OCTAGON, hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_D2, h_tol_D2, v_tol_D2);
 
 ! big corrector for crabs
 !g_MC2=0.037000;r_MC2=0.042000; !equal to D2 for the time being
@@ -105,10 +80,8 @@ exec,aperture_2in1_def(MBRD.4,d2_aperture,
 !g_MC2=g_D2;r_MC2=r_D2; !equal to D2 for the time being
 !r_tol_MC2 =r_tol_D2; h_tol_MC2 :=h_tol_D2+h_tol_MC2_mod; v_tol_MC2 :=v_tol_D2+v_tol_MC2_mod;
 
-exec,aperture_2in1_def(MCBRDH.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2 , h_tol_C2 , v_tol_C2);
-exec,aperture_2in1_def(MCBRDV.4,d2_aperture,
-          hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2 , h_tol_C2 , v_tol_C2);
+exec,aperture_2in1_def(MCBRDH.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2,h_tol_C2,v_tol_C2);
+exec,aperture_2in1_def(MCBRDV.4,OCTAGON,hv_D2,hv_D2,angle1_D2,angle2_D2,r_tol_C2,h_tol_C2,v_tol_C2);
 
 
 

--- a/build/tasks/check_thinthick.py
+++ b/build/tasks/check_thinthick.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import sys
+from glob import glob
+
+from numpy import *
+
+from pyoptics import *
+
+
+def check(t1,t2,i1,i2,name,check='rel',threshold=0):
+    v1=t1(name)[i1]
+    v2=t2(name)[i2]
+    if check=='rel':
+      tt=v2/v1-1
+    elif check=='abs':
+      tt=v2-v1
+    if abs(tt)>threshold:
+        print("%s %-15s: %8g %8g %-4s %12g"%(name,t1.name[i1],v1,v2,check,tt))
+
+def check_all(tkfn,tnfn):
+    print(tkfn,tnfn)
+    tk=optics.open(tkfn)
+    tn=optics.open(tnfn)
+    tkidx=where((tk.l==0)&~(tk//'^D'))[0]
+    tnidx=tn.idx_from_namelist(tk.name[tkidx])
+    for ii,jj in zip(tkidx,tnidx):
+        check(tk,tn,ii,jj,'s','abs',1e-9)
+        check(tk,tn,ii,jj,'betx','rel',0.015)
+        check(tk,tn,ii,jj,'bety','rel',0.015)
+#        check(tk,tn,ii,jj,'x/sqrt(betx)','abs',0.0)
+#        check(tk,tn,ii,jj,'y/sqrt(bety)','abs',0.0)
+        check(tk,tn,ii,jj,'dx/sqrt(betx)','abs',1e-4)
+        check(tk,tn,ii,jj,'dy/sqrt(bety)','abs',1e-4)
+
+
+
+tkname='squeeze'
+tnname=tkname+'_thin'
+
+tknames=glob(tkname+'/*')
+tnnames=glob(tnname+'/*')
+
+for tkname,tnname in sorted(zip(tknames,tnnames)):
+ for beam in '12':
+  tkfn="%s/twiss_lhcb%s.tfs"%(tkname,beam)
+  tnfn="%s/twiss_lhcb%s.tfs"%(tnname,beam)
+  check_all(tkfn,tnfn)

--- a/build/tasks/ex_data
+++ b/build/tasks/ex_data
@@ -1,0 +1,5 @@
+for fn in $1/*/result.tgz
+do
+echo $fn
+tar xvfz $fn -C `dirname $fn`
+done

--- a/build/tasks/job_mkpresqueeze.madx
+++ b/build/tasks/job_mkpresqueeze.madx
@@ -1,0 +1,131 @@
+option, warn,info;
+system,"rm -rf temp"; system,"mkdir temp";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/HLLHCV1.3 slhc";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/runIII lhc";
+
+Option, -echo,-warn,-info;
+call,file="lhc/lhc.seq";
+call,file="slhc/toolkit/macro.madx";
+call,file="slhc/toolkit/optics_log.madx";
+Option, -echo,warn,-info,no_fatal_stop;
+
+
+exec,mk_beam(7000);
+seqedit,sequence=lhcb1; flatten; cycle,start=s.ds.l3.b1; endedit;
+seqedit,sequence=lhcb2; flatten; cycle,start=s.ds.l3.b2; endedit;
+
+call,file="slhc/hllhc_sequence.madx";
+call,file="slhc/opt_inj.madx";
+exec,check_ip(b1); exec,check_ip(b2);
+
+delete,table=ir2sq1;
+exec,make_opticstbl_ir2(ir2sq1);
+fill,table=ir2sq1;
+call,file="slhc/opt_500_500_500_500.madx";
+fill,table=ir2sq1;
+
+
+readmytable,file="slhc/ir5/ir5sqfv3.tfs",table=ir5sq2;
+readmytable,file="slhc/ir8/ir8sq.tfs",table=ir8sq2;
+
+
+make_opt(bbb5,bbb8) : macro={
+
+call,file="slhc/toolkit/rematch_arcs.madx";
+call,file="slhc/toolkit/rephase_weak.madx";
+
+grad=132.6; scl=0.12; sch=0.90;sc79=0.99;bmaxds=200;imb=1.20;
+apq1011=1200; apq789:=apq1011; apq6:=apq789; apq5:=apq6;apq4:=apq5;
+match_inj_tunes=0;
+match_on_triplet=0;
+on_holdselect=0; jac_calls=   10;jac_tol=1e-20; jac_bisec=3; tar=0;
+call,file="slhc/toolkit/rematch_ir15b12.madx";
+call,file="slhc/toolkit/rematch_ir2b12.madx";
+call,file="slhc/toolkit/rematch_ir8b12.madx";
+call,file="slhc/toolkit/rematch_ir3b1.madx";
+call,file="slhc/toolkit/rematch_ir3b2.madx";
+call,file="slhc/toolkit/rematch_ir4b1.madx";
+call,file="slhc/toolkit/rematch_ir4b2.madx";
+nomatch_dx=1;
+call,file="slhc/toolkit/rematch_ir6b1.madx";
+call,file="slhc/toolkit/rematch_ir6b2.madx";
+nomatch_dx=0;
+call,file="slhc/toolkit/rematch_ir7b1.madx";
+call,file="slhc/toolkit/rematch_ir7b2.madx";
+
+
+value,tarir2b1,tarir3b1,tarir4b1,tarir5b1,tarir6b1,tarir7b1,tarir8b1;
+value,tarir2b2,tarir3b2,tarir4b2,tarir5b2,tarir6b2,tarir7b2,tarir8b2;
+
+tarir=tarir2b1+tarir3b1+tarir4b1+tarir5b1+tarir6b1+tarir7b1+tarir8b1+
+      tarir2b2+tarir3b2+tarir4b2+tarir5b2+tarir6b2+tarir7b2+tarir8b2;
+
+
+call,file="slhc/toolkit/rematch_xing_ir15.madx";
+call,file="slhc/toolkit/rematch_xing_ir28.madx";
+value,tarir,tar_xing_ir15,tar_xing_ir28;
+
+call,file="slhc/toolkit/rematch_w.madx";
+call,file="slhc/toolkit/rematch_disp.madx";
+call,file="slhc/toolkit/rematch_crabs.madx";
+call,file="slhc/toolkit/mk_arc_trims.madx";
+
+value,tarir,tar_xing_ir15,tar_xing_ir28,tar_on_disp;
+
+if (betxip5b1>=2){on_disp=0;};
+
+if (is_thin==0){exec,save_optics_hllhc(opt_squeeze_bbb5_bbb8.madx);};
+if (is_thin==1){exec,save_optics_hllhc(opt_squeeze_bbb5_bbb8_thin.madx);};
+};
+
+set_opt(bbb5,bbb8,kkk2): macro={
+call,file="slhc/opt_inj.madx";
+if (MBX.4L2->l==0) {is_thin=1;};
+
+ref5=bbb5/1000;
+betxip5b1=11;iii=61;while(betxip5b1>=ref5 && iii>0){
+setvars,table=ir5sq2,row=iii;iii=iii-1; };
+setvars_lin,table=ir5sq2,row1=iii+2,row2=iii+1,param=ttt5;
+ttt5=0;bb1=betxip5b1; ttt5=1;bb2=betxip5b1;
+ttt5=(bb1-ref5)/(bb1-bb2);!value,ttt5,betxip5b1,ref5;
+exec,copyir5to1;
+
+ref8=bbb8/1000;
+betxip8b1=11;iii=21;while(betxip8b1>=ref8 && iii>0){
+setvars,table=ir8sq2,row=iii;iii=iii-1; };
+setvars_lin,table=ir8sq2,row1=iii+2,row2=iii+1,param=ttt8;
+ttt8=0;bb1=betxip8b1; ttt8=1;bb2=betxip8b1;
+ttt8=(bb1-ref8)/(bb1-bb2);!value,ttt8,betxip8b1,ref8;
+
+!setvars,table=ir5sq2,row=row5;exec,copyir5to1;
+!setvars,table=ir8sq2,row=row8;
+setvars_lin,table=ir2sq1,row1=1,row2=2,param=kkk2/100;
+value,kqx.l2,kqx.r2;
+
+value,betxip5b1,betxip8b1,kqx.l2*23348;
+exec,check_ip(b1); exec,check_ip(b2);
+
+exec,make_opt(bbb5,bbb8);
+};
+
+!return;
+exec,set_opt(%B5,%B8,%B2);
+exec,myslice;
+exec,set_opt(%B5,%B8,%B2);
+
+
+!system,"cp opt*.madx presqueeze_lhcb/%B5_%B8_%B2/";
+system,"tar cvfz result.tgz *.madx *.tfs";
+
+!return;
+!exec,set_opt(6000,10000,0);
+!exec,myslice;
+!exec,set_opt(6000,10000,0);
+
+!exec,set_opt(500,3000,100);
+!exec,myslice;
+!exec,set_opt(500,3000,100);
+
+!exec,set_opt(500,3000,100);
+!exec,set_opt(4100,4100,100);
+

--- a/build/tasks/job_mksqueeze_lhcb.madx
+++ b/build/tasks/job_mksqueeze_lhcb.madx
@@ -1,0 +1,73 @@
+option, warn,info;
+system,"rm -rf temp"; system,"mkdir temp";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/HLLHCV1.3 slhc";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/runIII lhc";
+
+Option, -echo,-warn,-info;
+call,file="lhc/lhc.seq";
+call,file="slhc/toolkit/macro.madx";
+call,file="slhc/toolkit/optics_log.madx";
+Option, -echo,warn,-info,no_fatal_stop;
+
+
+exec,mk_beam(7000);
+seqedit,sequence=lhcb1; flatten; cycle,start=s.ds.l3.b1; endedit;
+seqedit,sequence=lhcb2; flatten; cycle,start=s.ds.l3.b2; endedit;
+
+call,file="slhc/hllhc_sequence.madx";
+call,file="slhc/opt_500_500_500_500.madx";
+exec,check_ip(b1); exec,check_ip(b2);
+
+make_opt(bbb): macro={
+if(is_thin==0){
+if (bbb<=500){call,file="slhc/squeeze/opt_bbb_bbb_bbb_bbb.madx";};
+if (bbb>500) {call,file="slhc/squeeze/opt_squeeze_bbb_3000.madx";};
+};
+if(is_thin==1){
+if (bbb<=500){call,file="slhc/squeeze/opt_bbb_bbb_bbb_bbb_thin.madx";};
+if (bbb>500) {call,file="slhc/squeeze/opt_squeeze_bbb_3000_thin.madx";};
+};
+exec,check_ip(b1); exec,check_ip(b2);
+
+scxir1=betx_IP1/betx0_IP1;
+scyir1=bety_IP1/bety0_IP1;
+
+
+exec,selectIRAUX(7,8,1,2,3,b1,scxir1,scyir1,betx0_ip1,bety0_ip1);
+exec,selectIRAUX(7,8,1,2,3,b2,scxir1,scyir1,betx0_ip1,bety0_ip1);
+on_holdselect=1;
+exec,mk_irtwiss(8,b1); exec,mk_irtwiss(8,b2);
+betxip8b1=3;
+betxip8b2:=betxip8b1;
+betyip8b1:=betxip8b1;
+betyip8b2:=betxip8b1;
+apq8=2512; apq6=apq8; apq7=apq8;
+scl=0.15; sch=0.99;
+no_match_beta=0; jac_calls=10; jac_tol=1e-14;
+while(betxip8b1>1.4){
+  betxip8b1=betxip8b1-0.1;
+  match_on_triplet=0; call,file="slhc/toolkit/rematch_ir8b12.madx";
+};
+call,file="slhc/toolkit/rematch_xing_ir28.madx";
+call,file="slhc/toolkit/rematch_w.madx";
+call,file="slhc/toolkit/rematch_disp.madx";
+
+if (bbb<=500){
+    if (is_thin==0){exec,save_optics_hllhc(opt_bbb_bbb_bbb_bbb.madx);};
+    if (is_thin==1){exec,save_optics_hllhc(opt_bbb_bbb_bbb_bbb_thin.madx);};
+};
+if (bbb>500){
+    if (is_thin==0){exec,save_optics_hllhc(opt_squeeze_bbb_1500.madx);};
+    if (is_thin==1){exec,save_optics_hllhc(opt_squeeze_bbb_1500_thin.madx);};
+};
+
+};
+
+
+exec,make_opt(%BBB);
+exec,myslice;
+exec,make_opt(%BBB);
+
+system,"tar cvfz result.tgz *.madx *.tfs";
+
+stop;

--- a/build/tasks/job_mksqueeze_noms10.madx
+++ b/build/tasks/job_mksqueeze_noms10.madx
@@ -1,0 +1,56 @@
+option, warn,info;
+system,"rm -rf temp"; system,"mkdir temp";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/HLLHCV1.3 slhc";
+system,"ln -fns /afs/cern.ch/eng/lhc/optics/runIII lhc";
+
+Option, -echo,-warn,-info;
+call,file="lhc/lhc.seq";
+call,file="slhc/toolkit/macro.madx";
+call,file="slhc/toolkit/optics_log.madx";
+Option, -echo,warn,-info,no_fatal_stop;
+
+
+exec,mk_beam(7000);
+seqedit,sequence=lhcb1; flatten; cycle,start=s.ds.l3.b1; endedit;
+seqedit,sequence=lhcb2; flatten; cycle,start=s.ds.l3.b2; endedit;
+
+call,file="slhc/hllhc_sequence.madx";
+exec, DISABLE_SEXT(MS.10);
+
+call,file="slhc/opt_500_500_500_500.madx";
+exec,check_ip(b1); exec,check_ip(b2);
+
+make_opt(bbb): macro={
+if(is_thin==0){
+if (bbb<=500){call,file="slhc/squeeze/opt_bbb_bbb_bbb_bbb.madx";};
+if (bbb>500) {call,file="slhc/squeeze/opt_squeeze_bbb_3000.madx";};
+};
+if(is_thin==1){
+if (bbb<=500){call,file="slhc/squeeze/opt_bbb_bbb_bbb_bbb_thin.madx";};
+if (bbb>500) {call,file="slhc/squeeze/opt_squeeze_bbb_3000_thin.madx";};
+};
+call,file="slhc/toolkit/rematch_w.madx";
+call,file="slhc/toolkit/rematch_disp.madx";
+call,file="slhc/toolkit/rematch_crabs.madx";
+call,file="slhc/toolkit/mk_arc_trims.madx";
+on_cutms.10f=1;
+on_cutms.10d=1;
+if (is_thin==0){
+   if (bbb<=500){exec,save_optics_hllhc(opt_bbb_bbb_bbb_bbb.madx);};
+   if (bbb>500) {exec,save_optics_hllhc(opt_squeeze_bbb_3000.madx);};
+};
+if (is_thin==1){
+   if (bbb<=500){exec,save_optics_hllhc(opt_bbb_bbb_bbb_bbb_thin.madx);};
+   if (bbb>500) {exec,save_optics_hllhc(opt_squeeze_bbb_3000_thin.madx);};
+};
+};
+
+!return;
+
+exec,make_opt(%BBB);
+exec,myslice;
+exec,make_opt(%BBB);
+
+system,"tar cvfz result.tgz *.madx *.tfs";
+
+stop;

--- a/build/tasks/mk_presqueeze.py
+++ b/build/tasks/mk_presqueeze.py
@@ -1,0 +1,19 @@
+import os
+
+from scan import Scan
+
+
+b5=list(range(6000,1000,-200)+range(1000,490,-10))
+b8=range(10000,3000,-500)
+b2=range(0,100,100/len(b8))
+b8+=[3000]*(len(b5)-len(b8))
+b2+=[100]*(len(b5)-len(b2))
+bbb=zip(b5,b8,b2)
+
+
+sc=Scan('job_mkpresqueeze.madx','presqueeze',
+        b5=b5,b2=b2,b8=b8)
+
+sc.mk_cases()
+#sc.exe_local(4)
+sc.exe_condor(runtime=30*60,out='result.tgz')

--- a/build/tasks/mk_presqueeze_lhcb.py
+++ b/build/tasks/mk_presqueeze_lhcb.py
@@ -1,0 +1,19 @@
+import os
+
+from scan import Scan
+
+
+b5=list(range(6000,1000,-200)+range(1000,490,-10))
+b8=range(10000,1500,-500)
+b2=range(0,100,100/len(b8))
+b8+=[1500]*(len(b5)-len(b8))
+b2+=[100]*(len(b5)-len(b2))
+bbb=zip(b5,b8,b2)
+
+
+sc=Scan('job_mkpresqueeze.madx','presqueeze_lhcb',
+        b5=b5,b2=b2,b8=b8)
+
+sc.mk_cases()
+#sc.exe_local(4)
+sc.exe_condor(runtime=30*60,out='result.tgz')

--- a/build/tasks/mk_squeeze_lhcb.py
+++ b/build/tasks/mk_squeeze_lhcb.py
@@ -1,0 +1,10 @@
+import os
+
+from scan import Scan
+
+
+sc=Scan('job_mksqueeze_lhcb.madx','squeeze_lhcb',
+        bbb=list(range(1000,140,-10)))
+
+sc.mk_cases()
+sc.exe_condor(runtime=30*60,out='result.tgz')

--- a/build/tasks/mk_squeeze_noms10.py
+++ b/build/tasks/mk_squeeze_noms10.py
@@ -1,0 +1,10 @@
+import os
+
+from scan import Scan
+
+
+sc=Scan('job_mksqueeze_noms10.madx','squeeze_noms10',
+        bbb=list(range(1000,140,-10)))
+
+sc.mk_cases()
+#sc.exe_condor()

--- a/build/tasks/mk_squeeze_noms10_rest.py
+++ b/build/tasks/mk_squeeze_noms10_rest.py
@@ -1,0 +1,10 @@
+import os
+
+from scan import Scan
+
+
+sc=Scan('job_mksqueeze_noms10.madx','squeeze_noms10',
+        bbb=[170,320,360,370,480])
+
+sc.mk_cases()
+sc.exe_condor()

--- a/build/tasks/scan.py
+++ b/build/tasks/scan.py
@@ -75,6 +75,7 @@ class Scan(object):
         else:
            outline='transfer_output_files   = %s'%out
         data['outline']=outline
+        data['cases']=', '.join([self.get_case_dir(case) for case in self.get_cases()])
         tmp="""\
         executable              = madx_wrapper.sh
         arguments               = {mask}
@@ -85,7 +86,8 @@ class Scan(object):
         transfer_input_files    = {mask}
         {outline}
         +MaxRuntime = {runtime}
-        queue dirname matching ({studydir}/*)
+        queue dirname in {cases}
+        ##queue dirname matching ({studydir}/*)
         """.format(**data)
         fn="%s.condor"%self.studydir
         open(fn,'w').write(tmp)

--- a/build/tasks/tr_data
+++ b/build/tasks/tr_data
@@ -5,5 +5,5 @@ do
     echo $i
     condor_transfer_data $i && condor_rm $i
   done
-  sleep 1
+  sleep 30
 done

--- a/toolkit/align_sepdip.madx
+++ b/toolkit/align_sepdip.madx
@@ -1,45 +1,45 @@
 align_elem(RREF,EELEM,SSHIFT): macro={
-stest=table(survey,EELEM,s);
-value,stest;
-if ( stest > 1e-9 ) {
-ttt=table(survey,RREF,theta); ctt=cos(ttt);stt=sin(ttt);
-xvz=stt; xvx=-ctt; zvz=ctt; zvx=stt; ! x and s directions
-zzz=table(survey,EELEM,z)-table(survey,RREF,z);
-xxx=table(survey,EELEM,x)-table(survey,RREF,x);
-dx_EELEM=zzz*xvz+xxx*xvx;
-sx_EELEM=zzz*zvz+xxx*zvx;
-value,dx_EELEM,sx_EELEM;
-if (dx_EELEM>0){
-   dx_EELEM=dx_EELEM-(SSHIFT/2000);
-} else {
-   dx_EELEM=dx_EELEM+(SSHIFT/2000);
-};
-value,dx_EELEM;
-select, flag=error, range=EELEM;
-ealign, dx=dx_EELEM;
-select, flag=error, clear;
-};
+  stest=table(survey,EELEM,s);
+  value,stest;
+  if ( stest > 1e-9 ) {
+    ttt=table(survey,RREF,theta); ctt=cos(ttt);stt=sin(ttt);
+    xvz=stt; xvx=-ctt; zvz=ctt; zvx=stt; ! x and s directions
+    zzz=table(survey,EELEM,z)-table(survey,RREF,z);
+    xxx=table(survey,EELEM,x)-table(survey,RREF,x);
+    dx_EELEM=zzz*xvz+xxx*xvx;
+    sx_EELEM=zzz*zvz+xxx*zvx;
+    value,dx_EELEM,sx_EELEM;
+    if (dx_EELEM>0){
+      dx_EELEM=dx_EELEM-(SSHIFT/2000);
+    } else {
+      dx_EELEM=dx_EELEM+(SSHIFT/2000);
+    };
+    value,dx_EELEM;
+    select, flag=error, range=EELEM;
+    ealign, dx=dx_EELEM;
+    select, flag=error, clear;
+  };
 };
 
 align_slice(RREF,EELEM,NSLICE,SSHIFT): macro={
-exec,align_elem(RREF,EELEM..NSLICE,SSHIFT);
+  exec,align_elem(RREF,EELEM..NSLICE,SSHIFT);
 };
 
 align_group(RREF,EELEM,SSHIFT): macro={
-align_group_n=0;
-stest=1;
-while(align_group_n<64 && stest>1e-9){
-  align_group_n=align_group_n+1;
-  exec,align_slice(RREF,EELEM,$align_group_n,SSHIFT);
-};
+  align_group_n=0;
+  stest=1;
+  while(align_group_n<64 && stest>1e-9){
+    align_group_n=align_group_n+1;
+    exec,align_slice(RREF,EELEM,$align_group_n,SSHIFT);
+  };
 };
 
 align_mbxw_group(EELEM): macro={
-value,EELEM;
-exec,align_elem(IP1.L1, EELEM4l1,0);
-exec,align_elem(IP1   , EELEM4r1,0);
-exec,align_elem(IP5   , EELEM4l5,0);
-exec,align_elem(IP5   , EELEM4r5,0);
+  value,EELEM;
+  exec,align_elem(IP1.L1, EELEM4l1,0);
+  exec,align_elem(IP1   , EELEM4r1,0);
+  exec,align_elem(IP5   , EELEM4l5,0);
+  exec,align_elem(IP5   , EELEM4r5,0);
 };
 
 
@@ -87,67 +87,67 @@ align_mbx28: macro={
 };
 
 align_mbtype(MBTYP,IPN): macro={
-if (mylhcbeam == 1){
- if (IPN==1){
-   exec,align_group(IP1.L1,MBTYP.4lIPN.b1,MBTYP_mech_sep);
- } else {
-   exec,align_group(IPIPN,MBTYP.4lIPN.b1,MBTYP_mech_sep);
- };
- exec,align_group(IPIPIPN,MBTYP.4r2.b1,MBTYP_mech_sep);
-};
-if (mylhcbeam == 2 || mylhcbeam == 4){
- if (IPN==1){
-   exec,align_group(IP1.L1,MBTYP.4lIPN.b2,MBTYP_mech_sep);
- } else {
-   exec,align_group(IPIPN,MBTYP.4lIPN.b2,MBTYP_mech_sep);
- };
- exec,align_group(IPIPIPN,MBTYP.4r2.b2,MBTYP_mech_sep);
-};
+  if (mylhcbeam == 1){
+    if (IPN==1){
+      exec,align_group(IP1.L1,MBTYP.4lIPN.b1,MBTYP_mech_sep);
+    } else {
+      exec,align_group(IPIPN,MBTYP.4lIPN.b1,MBTYP_mech_sep);
+    };
+    exec,align_group(IPIPIPN,MBTYP.4r2.b1,MBTYP_mech_sep);
+  };
+  if (mylhcbeam == 2 || mylhcbeam == 4){
+    if (IPN==1){
+      exec,align_group(IP1.L1,MBTYP.4lIPN.b2,MBTYP_mech_sep);
+    } else {
+      exec,align_group(IPIPN,MBTYP.4lIPN.b2,MBTYP_mech_sep);
+    };
+    exec,align_group(IPIPIPN,MBTYP.4r2.b2,MBTYP_mech_sep);
+  };
 };
 
 align_mbrd15(mbrd_mech_sep): macro={
-if (mylhcbeam == 1){
- exec,align_group(IP1.L1,mbrd.4l1.b1,mbrd_mech_sep);
- exec,align_group(IP1,mbrd.4r1.b1,mbrd_mech_sep);
- exec,align_group(IP5,mbrd.4l5.b1,mbrd_mech_sep);
- exec,align_group(IP5,mbrd.4r5.b1,mbrd_mech_sep);
-};
-if (mylhcbeam == 2 || mylhcbeam == 4){
- exec,align_group(IP1.L1,mbrd.4l1.b2,mbrd_mech_sep);
- exec,align_group(IP1,mbrd.4r1.b2,mbrd_mech_sep);
- exec,align_group(IP5,mbrd.4l5.b2,mbrd_mech_sep);
- exec,align_group(IP5,mbrd.4r5.b2,mbrd_mech_sep);
-};
+  if (mylhcbeam == 1){
+    exec,align_group(IP1.L1,mbrd.4l1.b1,mbrd_mech_sep);
+    exec,align_group(IP1,mbrd.4r1.b1,mbrd_mech_sep);
+    exec,align_group(IP5,mbrd.4l5.b1,mbrd_mech_sep);
+    exec,align_group(IP5,mbrd.4r5.b1,mbrd_mech_sep);
+  };
+  if (mylhcbeam == 2 || mylhcbeam == 4){
+    exec,align_group(IP1.L1,mbrd.4l1.b2,mbrd_mech_sep);
+    exec,align_group(IP1,mbrd.4r1.b2,mbrd_mech_sep);
+    exec,align_group(IP5,mbrd.4l5.b2,mbrd_mech_sep);
+    exec,align_group(IP5,mbrd.4r5.b2,mbrd_mech_sep);
+  };
 };
 
 align_mbrc28: macro={
-if (mylhcbeam == 1){
- exec,align_group(IP2,mbrc.4l2.b1,mbrc_mech_sep);
- exec,align_group(IP2,mbrc.4r2.b1,mbrc_mech_sep);
- exec,align_group(IP8,mbrc.4l8.b1,mbrc_mech_sep);
- exec,align_group(IP8,mbrc.4r8.b1,mbrc_mech_sep);
-};
-if (mylhcbeam == 2 || mylhcbeam == 4){
- exec,align_group(IP2,mbrc.4l2.b2,mbrc_mech_sep);
- exec,align_group(IP2,mbrc.4r2.b2,mbrc_mech_sep);
- exec,align_group(IP8,mbrc.4l8.b2,mbrc_mech_sep);
- exec,align_group(IP8,mbrc.4r8.b2,mbrc_mech_sep);
-};
+  if (mylhcbeam == 1){
+    exec,align_group(IP2,mbrc.4l2.b1,mbrc_mech_sep);
+    exec,align_group(IP2,mbrc.4r2.b1,mbrc_mech_sep);
+    exec,align_group(IP8,mbrc.4l8.b1,mbrc_mech_sep);
+    exec,align_group(IP8,mbrc.4r8.b1,mbrc_mech_sep);
+  };
+  if (mylhcbeam == 2 || mylhcbeam == 4){
+    exec,align_group(IP2,mbrc.4l2.b2,mbrc_mech_sep);
+    exec,align_group(IP2,mbrc.4r2.b2,mbrc_mech_sep);
+    exec,align_group(IP8,mbrc.4l8.b2,mbrc_mech_sep);
+    exec,align_group(IP8,mbrc.4r8.b2,mbrc_mech_sep);
+  };
 };
 
 align_mbrc15: macro={
-if (mylhcbeam == 1){
- exec,align_group(IP1.L1,mbrc.4l1.b1,mbrc_mech_sep);
- exec,align_group(IP1,mbrc.4r1.b1,mbrc_mech_sep);
- exec,align_group(IP5,mbrc.4l5.b1,mbrc_mech_sep);
- exec,align_group(IP5,mbrc.4r5.b1,mbrc_mech_sep);
-};
-if (mylhcbeam == 2 || mylhcbeam == 4){
- exec,align_group(IP1.L1,mbrc.4l1.b2,mbrc_mech_sep);
- exec,align_group(IP1,mbrc.4r1.b2,mbrc_mech_sep);
- exec,align_group(IP5,mbrc.4l5.b2,mbrc_mech_sep);
- exec,align_group(IP5,mbrc.4r5.b2,mbrc_mech_sep);
-};
+  if (mylhcbeam == 1){
+    exec,align_group(IP1.L1,mbrc.4l1.b1,mbrc_mech_sep);
+    exec,align_group(IP1,mbrc.4r1.b1,mbrc_mech_sep);
+    exec,align_group(IP5,mbrc.4l5.b1,mbrc_mech_sep);
+    exec,align_group(IP5,mbrc.4r5.b1,mbrc_mech_sep);
+  };
+  if (mylhcbeam == 2 || mylhcbeam == 4){
+    exec,align_group(IP1.L1,mbrc.4l1.b2,mbrc_mech_sep);
+    exec,align_group(IP1,mbrc.4r1.b2,mbrc_mech_sep);
+    exec,align_group(IP5,mbrc.4l5.b2,mbrc_mech_sep);
+    exec,align_group(IP5,mbrc.4r5.b2,mbrc_mech_sep);
+  };
 };
 
 


### PR DESCRIPTION
This replaces the apertype files for D2, Q1, Q2, Q3 and Q4 with octagon apertypes.
The angles were also set in degrees for values aper_3 and aper_4. They should be in radians.